### PR TITLE
Remove copyright notice about CP Editor

### DIFF
--- a/include/LSPClient.hpp
+++ b/include/LSPClient.hpp
@@ -1,20 +1,3 @@
-/*
- * Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com>
- *
- * This file is part of cpeditor.
- *
- * cpeditor is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * I will not be responsible if cpeditor behaves in unexpected way and
- * causes your ratings to go down and or lose any important contest.
- *
- * Believe Software is "Software" and it isn't immune to bugs.
- *
- */
-
 #ifndef LSPCLIENT_HPP
 #define LSPCLIENT_HPP
 

--- a/src/LSPClient.cpp
+++ b/src/LSPClient.cpp
@@ -1,20 +1,3 @@
-/*
- * Copyright (C) 2019-2020 Ashar Khan <ashar786khan@gmail.com>
- *
- * This file is part of cpeditor.
- *
- * cpeditor is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * I will not be responsible if cpeditor behaves in unexpected way and
- * causes your ratings to go down and or lose any important contest.
- *
- * Believe Software is "Software" and it isn't immune to bugs.
- *
- */
-
 #include <LSPClient.hpp>
 #include <QCoreApplication>
 #include <QJsonDocument>


### PR DESCRIPTION
LSPClient is a submodule of CP Editor, not part of CP Editor, and the LICENSE in the root directory is Apache 2.0, so the old copyright notice is very confusing.

I think deleting that notice is enough to solve this problem, and it's not necessary to add a copyright notice for Apache 2.0.

Another way to resolve this is to re-license this project under GPL 3.0 or later.