### PR TITLE
build: remove the -ansi compile option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ target_include_directories(LSPClient PUBLIC
 if(CMAKE_COMPILER_IS_GNUCXX)
     target_compile_options(LSPClient
 		PRIVATE
-		-ansi
 		-pedantic
 		-Wall
 		-Wextra


### PR DESCRIPTION
It conflicts with -std=gnu++17 and fails to build with CMake 3.26